### PR TITLE
update/display()-spaces-should-be-present

### DIFF
--- a/C++/STACK/STACK_USING_ARRAY.cpp
+++ b/C++/STACK/STACK_USING_ARRAY.cpp
@@ -65,7 +65,7 @@ void arr_stack::pop()
 void arr_stack::display()
 {
     for (int i=0;i<=top;i++)
-       cout<<ptr[i];
+       cout<<ptr[i]<<" ";
 }
 arr_stack::~arr_stack()
 {


### PR DESCRIPTION
Spaces should be present between elements while printing them.